### PR TITLE
Opencircuit.nl product link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ description: >-
 Je vindt hier de documentatie over de DSMRloggerAPI firmware voor versie 4 van de DSMR-logger.
 
 {% hint style="info" %}
-De DSMR-logger v4.5 die je via [opencircuit.nl](https://opencircuit.shop/Product/Smart-meter-reader-V4.5-Assembled-programmed) kunt kopen \(na juni 2021\) is voorzien van de hier beschreven firmware. Deze DSMR-logger is "Plug-And-Play" en alleen in bijzondere gevallen moet er iets aan de instellingen aangepast worden \(bijvoorbeeld als je een hele oude Slimme Meter hebt of als je een zgn. "Enkel Fase" Slimme meter hebt\).
+De DSMR-logger v4.5 die je via [opencircuit.nl](https://opencircuit.shop/product/slimme-meter-uitlezer-v4.5-geassembleerd) kunt kopen \(na juni 2021\) is voorzien van de hier beschreven firmware. Deze DSMR-logger is "Plug-And-Play" en alleen in bijzondere gevallen moet er iets aan de instellingen aangepast worden \(bijvoorbeeld als je een hele oude Slimme Meter hebt of als je een zgn. "Enkel Fase" Slimme meter hebt\).
 
 Deze documentatie is voor de gebruikers en makers die meer willen dan alleen de DSMR-logger aansluiten op hun Slimme meter. De meeste gebruikers zullen voldoende hebben aan alleen [dit](dsmr-editor.md#settings-aanpassen) hoofdstuk.
 {% endhint %}


### PR DESCRIPTION
Fixes dead hyperlink. Maybe update the text on opencircuit.nl too, to link link to the new API instead of WS documentation.